### PR TITLE
Add mass for proton and other ion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,7 @@ launch.json
 .pylintrc
 TODO.md
 phase_space.png
+
+#output files
+*.png
+output.md

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ pixi run start --opmd_path <path_to_your_openPMD_file> --species <particle_spe
 
 Replace descriptions between chevrons `<>` by relevant values, in this case the
 path to the PIC output file, name of the particle species (`e_all` or
-`e_highGamma` etc.), particle species mass (default = 1.0 for electron, 1836.152 for proton, or 22033.824 for carbon etc.), and an integer reduction factor `k`, typically between 2 and ~100.
+`e_highGamma` etc.), particle mass relative to the electron mass (default: 1.0) (1.0 for electron, 1836.152 for proton, or 22033.824 for carbon etc.), and an integer reduction factor `k`, typically between 2 and ~100.
 If the initial PIC file has `N` macroparticles, the resulting reduced file will have `N/k`
 macroparticles.
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ For production runs, use
 
 ```console
 $ cd openPMD-resampler
-$ pixi run start --opmd_path <path_to_your_openPMD_file> --species <electron_species_name> --reduction_factor <k>
+$ pixi run start --opmd_path <path_to_your_openPMD_file> --species <particle_species_name> --mass <particle mass> --reduction_factor <k>
 ```
 
 Replace descriptions between chevrons `<>` by relevant values, in this case the
-path to the PIC output file, name of the electron species (`e_all` or
-`e_highGamma` etc.) and an integer reduction factor `k`, typically between 2 and ~100.
+path to the PIC output file, name of the particle species (`e_all` or
+`e_highGamma` etc.), particle species mass (default = 1.0 for electron, 1836.152 for proton, or 22033.824 for carbon etc.), and an integer reduction factor `k`, typically between 2 and ~100.
 If the initial PIC file has `N` macroparticles, the resulting reduced file will have `N/k`
 macroparticles.
 

--- a/openpmd_resampler/df_to_txt.py
+++ b/openpmd_resampler/df_to_txt.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from .log import logger
 from .units import units
-from .utils import convert_bytes_to_gb
+from .utils import convert_bytes_to_mb, convert_bytes_to_gb
 
 
 class DataFrameToFile:
@@ -67,5 +67,5 @@ class DataFrameToFile:
 
         # Compute and log the file size
         file_size_bytes = os.path.getsize(file_path)
-        file_size_gb = convert_bytes_to_gb(file_size_bytes)
-        logger.info("Final file size: %.2f GB", file_size_gb)
+        file_size_mb = convert_bytes_to_mb(file_size_bytes)
+        logger.info("Final file size: %.2f MB", file_size_mb)

--- a/openpmd_resampler/df_to_txt.py
+++ b/openpmd_resampler/df_to_txt.py
@@ -43,7 +43,7 @@ class DataFrameToFile:
         if not self.include_weights:
             columns_to_write.remove("weights")
         if not self.include_energy:
-            columns_to_write.remove("energy_mev")
+            columns_to_write.remove("kinetic_energy_mev")
 
         # Write header to file
         with open(file_path, "w", encoding="utf-8") as f:

--- a/openpmd_resampler/df_to_txt.py
+++ b/openpmd_resampler/df_to_txt.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from .log import logger
 from .units import units
-from .utils import convert_bytes_to_mb, convert_bytes_to_gb
+from .utils import format_file_size
 
 
 class DataFrameToFile:
@@ -66,6 +66,5 @@ class DataFrameToFile:
         logger.info("Wrote %s\n", file_path)
 
         # Compute and log the file size
-        file_size_bytes = os.path.getsize(file_path)
-        file_size_mb = convert_bytes_to_mb(file_size_bytes)
-        logger.info("Final file size: %.2f MB", file_size_mb)
+        file_size = os.path.getsize(file_path)
+        logger.info("Final file size: %s\n", format_file_size(file_size))

--- a/openpmd_resampler/histograms.py
+++ b/openpmd_resampler/histograms.py
@@ -140,7 +140,7 @@ class StandardHistogram(Histogram):
 
 
 class StandardHistogramPlot(HistogramPlot):
-    y_label = "Number of 'real' electrons"
+    y_label = "Number of 'real' particles"
 
     def plot(self, x_coords, density, color):
         self.ax.plot(

--- a/openpmd_resampler/image_plots.py
+++ b/openpmd_resampler/image_plots.py
@@ -42,7 +42,7 @@ class DataShaderPlot(ABC):
         self,
         plot_styling: Callable = None,
         add_cbar=True,
-        cbar_label="Number of 'real' electrons",
+        cbar_label="Number of 'real' particles",
     ):
         if plot_styling is None:
             plot_styling = self.default_plot_styling()

--- a/openpmd_resampler/reader.py
+++ b/openpmd_resampler/reader.py
@@ -183,8 +183,8 @@ class OpenPMDLoader:
 
         mass = self.particle_species_mass * constants.electron_mass_mev_c2
 
-        energy_mev = np.sqrt(momentum_x**2 + momentum_y**2 + momentum_z**2 + mass**2)
-        self.data["energy_mev"] = energy_mev - mass
+        kinetic_energy_mev = np.sqrt(momentum_x**2 + momentum_y**2 + momentum_z**2 + mass**2)
+        self.data["kinetic_energy_mev"] = kinetic_energy_mev - mass
 
 
 class DataFrameUpdater:
@@ -199,7 +199,7 @@ class DataFrameUpdater:
 
     def add_energy_column(self):
         mass = self.particle_species_mass * constants.electron_mass_mev_c2
-        self.df["energy_mev"] = np.sqrt(
+        self.df["kinetic_energy_mev"] = np.sqrt(
             self.df["momentum_x_mev_c"] ** 2
             + self.df["momentum_y_mev_c"] ** 2
             + self.df["momentum_z_mev_c"] ** 2
@@ -217,7 +217,7 @@ class DataAnalyzer:
         dataset_info(self.df)
 
         weighted_average_energy = np.average(
-            self.df["energy_mev"], weights=self.df["weights"]
+            self.df["kinetic_energy_mev"], weights=self.df["weights"]
         )
         logger.info(
             "The (weighted) mean energy is %.6e MeV.\n", weighted_average_energy

--- a/openpmd_resampler/reader.py
+++ b/openpmd_resampler/reader.py
@@ -23,9 +23,10 @@ class Attributes(Enum):
 
 
 class OpenPMDLoader:
-    def __init__(self, file_path: str, particle_species_name: str = "e_all"):
+    def __init__(self, file_path: str, particle_species_name: str = "e_all",particle_species_mass: float = 1.0):
         self.file_path = str(file_path)
         self.particle_species_name = particle_species_name
+        self.particle_species_mass = particle_species_mass
 
         self.series = self.open_series()
 
@@ -44,7 +45,7 @@ class OpenPMDLoader:
         logger.info("Detected particle species: %s.\n", detected_species)
         if self.particle_species_name not in detected_species:
             raise ValueError(f"Provided species '{self.particle_species_name}' not available. Detected species: {detected_species}")
-        self.electrons = self.iteration.particles[self.particle_species_name]
+        self.particles = self.iteration.particles[self.particle_species_name]
 
         self.data, self.units = self.get_particle_data_and_units()
 
@@ -92,13 +93,13 @@ class OpenPMDLoader:
 
         for attribute in Attributes:
             for component in Components:
-                data[f"{attribute.value}_{component.value}"] = self.electrons[
+                data[f"{attribute.value}_{component.value}"] = self.particles[
                     attribute.value
                 ][component.value].load_chunk()
-                units[f"{attribute.value}_{component.value}"] = self.electrons[
+                units[f"{attribute.value}_{component.value}"] = self.particles[
                     attribute.value
                 ][component.value].unit_SI
-                dimensions[f"{attribute.value}_{component.value}"] = self.electrons[
+                dimensions[f"{attribute.value}_{component.value}"] = self.particles[
                     attribute.value
                 ].unit_dimension
                 np.testing.assert_allclose(
@@ -108,13 +109,13 @@ class OpenPMDLoader:
                     rtol=0,
                 )
 
-        data["weights"] = self.electrons["weighting"][
+        data["weights"] = self.particles["weighting"][
             io.Record_Component.SCALAR
         ].load_chunk()
-        units["weights"] = self.electrons["weighting"][
+        units["weights"] = self.particles["weighting"][
             io.Record_Component.SCALAR
         ].unit_SI
-        dimensions["weights"] = self.electrons["weighting"].unit_dimension
+        dimensions["weights"] = self.particles["weighting"].unit_dimension
         np.testing.assert_allclose(
             dimensions["weights"], expected_dims.weights, atol=1e-9, rtol=0
         )
@@ -122,10 +123,10 @@ class OpenPMDLoader:
         return data, units
 
     def rescale_momenta(self):
-        macro_weighted = self.electrons[f"{Attributes.MOMENTUM.value}"].get_attribute(
+        macro_weighted = self.particles[f"{Attributes.MOMENTUM.value}"].get_attribute(
             "macroWeighted"
         )
-        weighting_power = self.electrons[f"{Attributes.MOMENTUM.value}"].get_attribute(
+        weighting_power = self.particles[f"{Attributes.MOMENTUM.value}"].get_attribute(
             "weightingPower"
         )
         if (macro_weighted == 1) and (weighting_power != 0):
@@ -180,8 +181,8 @@ class OpenPMDLoader:
         momentum_y = self.data[f"{Attributes.MOMENTUM.value}_y"]
         momentum_z = self.data[f"{Attributes.MOMENTUM.value}_z"]
 
-        energy_mev = np.sqrt(momentum_x**2 + momentum_y**2 + momentum_z**2 + constants.electron_mass_mev_c2**2)
-        self.data["energy_mev"] = energy_mev
+        energy_mev = np.sqrt(momentum_x**2 + momentum_y**2 + momentum_z**2 + self.particle_species_mass**2*constants.electron_mass_mev_c2**2)
+        self.data["energy_mev"] = energy_mev - self.particle_species_mass * constants.electron_mass_mev_c2
 
 
 class DataFrameUpdater:
@@ -199,9 +200,8 @@ class DataFrameUpdater:
             self.df["momentum_x_mev_c"] ** 2
             + self.df["momentum_y_mev_c"] ** 2
             + self.df["momentum_z_mev_c"] ** 2
-            + constants.electron_mass_mev_c2**2
-        )
-
+            + self.particle_species_mass**2*constants.electron_mass_mev_c2**2
+        ) - self.particle_species_mass * constants.electron_mass_mev_c2
 
 class DataAnalyzer:
     def __init__(self, df: pd.DataFrame):
@@ -222,16 +222,16 @@ class DataAnalyzer:
 
 
 class ParticleDataReader:
-    def __init__(self, file_path: str, particle_species_name: str = "e_all"):
-        self.loader = OpenPMDLoader(file_path, particle_species_name)
+    def __init__(self, file_path: str, particle_species_name: str = "e_all", particle_species_mass: float = 1.0):
+        self.loader = OpenPMDLoader(file_path, particle_species_name, particle_species_mass)
         self.updater = DataFrameUpdater(self.loader.df)
         self.analyzer = DataAnalyzer(self.updater.df)
 
     @classmethod
     def from_file(
-        cls, file_path: str, particle_species_name: str = "e_all"
+        cls, file_path: str, particle_species_name: str = "e_all", particle_species_mass: float = 1.0
     ) -> pd.DataFrame:
-        reader = cls(file_path, particle_species_name)
+        reader = cls(file_path, particle_species_name, particle_species_mass)
         return reader.df
 
     @property

--- a/openpmd_resampler/reader.py
+++ b/openpmd_resampler/reader.py
@@ -181,8 +181,10 @@ class OpenPMDLoader:
         momentum_y = self.data[f"{Attributes.MOMENTUM.value}_y"]
         momentum_z = self.data[f"{Attributes.MOMENTUM.value}_z"]
 
-        energy_mev = np.sqrt(momentum_x**2 + momentum_y**2 + momentum_z**2 + self.particle_species_mass**2*constants.electron_mass_mev_c2**2)
-        self.data["energy_mev"] = energy_mev - self.particle_species_mass * constants.electron_mass_mev_c2
+        mass = self.particle_species_mass * constants.electron_mass_mev_c2
+
+        energy_mev = np.sqrt(momentum_x**2 + momentum_y**2 + momentum_z**2 + mass**2)
+        self.data["energy_mev"] = energy_mev - mass
 
 
 class DataFrameUpdater:
@@ -196,12 +198,13 @@ class DataFrameUpdater:
         return self._df_or_class_with_df.df
 
     def add_energy_column(self):
+        mass = self.particle_species_mass * constants.electron_mass_mev_c2
         self.df["energy_mev"] = np.sqrt(
             self.df["momentum_x_mev_c"] ** 2
             + self.df["momentum_y_mev_c"] ** 2
             + self.df["momentum_z_mev_c"] ** 2
-            + self.particle_species_mass**2*constants.electron_mass_mev_c2**2
-        ) - self.particle_species_mass * constants.electron_mass_mev_c2
+            + mass**2
+        ) - mass
 
 class DataAnalyzer:
     def __init__(self, df: pd.DataFrame):

--- a/openpmd_resampler/resampling.py
+++ b/openpmd_resampler/resampling.py
@@ -108,10 +108,10 @@ class ParticleResampler:
         random_generator = np.random.default_rng(seed=77125)
 
         # Drop energy column
-        energy_mev_dropped = False
-        if "energy_mev" in self.df.columns:
-            self.df.drop(columns=["energy_mev"], inplace=True)
-            energy_mev_dropped = True
+        kinetic_energy_mev_dropped = False
+        if "kinetic_energy_mev" in self.df.columns:
+            self.df.drop(columns=["kinetic_energy_mev"], inplace=True)
+            kinetic_energy_mev_dropped = True
 
         # Repeat rows based on the 'weights' column
         self.df = self.df.loc[
@@ -136,7 +136,7 @@ class ParticleResampler:
         self.df.reset_index(drop=True, inplace=True)
 
         # Recompute energy column
-        if energy_mev_dropped:
+        if kinetic_energy_mev_dropped:
             self.updater.add_energy_column()
 
         return self

--- a/openpmd_resampler/resampling.py
+++ b/openpmd_resampler/resampling.py
@@ -35,7 +35,7 @@ class ParticleResampler:
     def random_weights(self) -> pd.DataFrame:
         min_weight = self.df[self.weight_column].min()
         max_weight = self.df[self.weight_column].max()
-        random_generator = np.random.default_rng(seed=42)
+        random_generator = np.random.default_rng(seed=77125)
         self.df[self.weight_column] = random_generator.uniform(
             min_weight, max_weight, size=self.df.shape[0]
         )
@@ -45,7 +45,7 @@ class ParticleResampler:
     def simple_thinning(self, number_of_remaining_macroparticles: int) -> pd.DataFrame:
         number_of_remaining_macroparticles = int(number_of_remaining_macroparticles)
 
-        random_generator = np.random.default_rng(seed=42)
+        random_generator = np.random.default_rng(seed=77125)
         number_of_initial_macroparticles = self.df.shape[0]
 
         # Generate random indices for deletion
@@ -79,7 +79,7 @@ class ParticleResampler:
         threshold_weight = k * average_weight
 
         # Generate random numbers for each particle
-        random_generator = np.random.default_rng(seed=42)
+        random_generator = np.random.default_rng(seed=77125)
         random_numbers = random_generator.uniform(0.0, 1.0, size=self.df.shape[0])
 
         # Create a mask for particles to be deleted
@@ -105,7 +105,7 @@ class ParticleResampler:
         Repeat each row based on the 'weights' column, set all 'weights' to 1,
         and add a small random value to the position and momentum columns.
         """
-        random_generator = np.random.default_rng(seed=42)
+        random_generator = np.random.default_rng(seed=77125)
 
         # Drop energy column
         energy_mev_dropped = False

--- a/openpmd_resampler/units.py
+++ b/openpmd_resampler/units.py
@@ -23,7 +23,7 @@ units = {
     "momentum_y_mev_c": Units.MOMENTUM.value,
     "momentum_z_mev_c": Units.MOMENTUM.value,
     "weights": Units.WEIGHTS.value,
-    "energy_mev": Units.ENERGY.value,
+    "kinetic_energy_mev": Units.ENERGY.value,
 }
 
 

--- a/openpmd_resampler/utils.py
+++ b/openpmd_resampler/utils.py
@@ -11,15 +11,16 @@ from PIL import Image
 from .log import logger
 from .units import constants
 
+def convert_bytes_to_mb(size_in_bytes):
+    """Convert size in bytes to megabytes (MB)"""
+    return size_in_bytes / (1024.0**2)
 
 def convert_bytes_to_gb(size_in_bytes):
     """Convert size in bytes to gigabytes (GB)"""
     return size_in_bytes / (1024.0**3)
 
-
 def thousand_separators(number):
     return f"{number:,}"
-
 
 def describe(df):
     desc = pd.DataFrame(index=['count', 'mean', 'std', 'min', 'max'])
@@ -35,7 +36,7 @@ def describe(df):
 
 def dataset_info(df: pd.DataFrame) -> None:
     logger.info(
-        "The dataset contains %s macroparticles, corresponding to %s 'real' electrons, "
+        "The dataset contains %s macroparticles, corresponding to %s 'real' particles, "
         "with a total charge of %.2f pC.\n",
         thousand_separators(df.shape[0]),
         thousand_separators(int(df["weights"].sum())),
@@ -46,7 +47,6 @@ def dataset_info(df: pd.DataFrame) -> None:
     description = describe(df)
     logger.info("%s\n", description)
     logger.info("```\n")
-
 
 def unique_filename(suffix: str) -> str:
     """
@@ -64,7 +64,6 @@ def unique_filename(suffix: str) -> str:
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as temp_file:
         temp_filename = temp_file.name
     return temp_filename
-
 
 def combine_images(filenames: List[str], output_filename: str) -> None:
     """

--- a/openpmd_resampler/utils.py
+++ b/openpmd_resampler/utils.py
@@ -11,13 +11,13 @@ from PIL import Image
 from .log import logger
 from .units import constants
 
-def convert_bytes_to_mb(size_in_bytes):
-    """Convert size in bytes to megabytes (MB)"""
-    return size_in_bytes / (1024.0**2)
-
-def convert_bytes_to_gb(size_in_bytes):
-    """Convert size in bytes to gigabytes (GB)"""
-    return size_in_bytes / (1024.0**3)
+def format_file_size(size_bytes):
+    """Convert file size to human-readable format."""
+    for unit in ['B', 'KB', 'MB', 'GB', 'TB']:
+        if size_bytes < 1024.0:
+            return f"{size_bytes:.2f} {unit}"
+        size_bytes /= 1024.0
+    return f"{size_bytes:.2f} PB"  # For petabyte-sized files just in case
 
 def thousand_separators(number):
     return f"{number:,}"

--- a/openpmd_resampler/visualize_phase_space.py
+++ b/openpmd_resampler/visualize_phase_space.py
@@ -66,7 +66,7 @@ class MultiplePanelPlotter(ABC):
 
 class MultipleHistogramPlotter(MultiplePanelPlotter):
     layout = (3, 3, 2)
-    energy_col = "energy_mev"
+    energy_col = "kinetic_energy_mev"
     energy_label = "Energy (MeV)"
 
     def __init__(self, df, output_filename=None):

--- a/start.py
+++ b/start.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument("--opmd_path", type=str, help="Path to the OpenPMD file")
     parser.add_argument("--species", "-s", type=str, default="e_all",
                         help="Particle species name (default: e_all)")
+    parser.add_argument("--mass", "-m", type=float, default=1.0,
+                        help="Particle mass (default: 1.0)")
     parser.add_argument("--reduction_factor", "-k", type=float, default=2.0,
                         help="The 'k' level for global leveling thinning (default: 2.0)")
     parser.add_argument("--no_plot", action="store_true",
@@ -27,12 +29,13 @@ def main():
     args = parser.parse_args()
     opmd_path = Path(args.opmd_path)
     particle_species_name = args.species
+    particle_species_mass = args.mass
     reduction_factor = args.reduction_factor
     no_plot = args.no_plot
     no_csv = args.no_csv
 
     # Create the dataframe
-    df = ParticleDataReader.from_file(opmd_path, particle_species_name=particle_species_name)
+    df = ParticleDataReader.from_file(opmd_path, particle_species_name=particle_species_name,particle_species_mass=particle_species_mass)
 
     # Apply thinning algorithm to df, resulting in df_thin
     resampler = ParticleResampler(df)
@@ -44,7 +47,7 @@ def main():
 
     if not no_csv:
         DataFrameToFile(df_thin).exclude_weights().exclude_energy().write_to_file(
-            opmd_path.with_suffix(".txt")
+            opmd_path.with_suffix(".dat")
         )
 
 

--- a/start.py
+++ b/start.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument("--species", "-s", type=str, default="e_all",
                         help="Particle species name (default: e_all)")
     parser.add_argument("--mass", "-m", type=float, default=1.0,
-                        help="Particle mass (default: 1.0)")
+                        help="Particle mass relative to the electron mass (default: 1.0)")
     parser.add_argument("--reduction_factor", "-k", type=float, default=2.0,
                         help="The 'k' level for global leveling thinning (default: 2.0)")
     parser.add_argument("--no_plot", action="store_true",

--- a/usage.py
+++ b/usage.py
@@ -17,6 +17,8 @@ def main():
     parser.add_argument("--opmd_path", type=str, help="Path to the OpenPMD file")
     parser.add_argument("--species", "-s", type=str, default="e_all",
                         help="Particle species name (default: e_all)")
+    parser.add_argument("--mass", "-m", type=float, default=1.0,
+                        help="Particle mass (default: 1.0)")
     parser.add_argument("--reduction_factor", "-k", type=float, default=2.0,
                         help="The 'k' level for global leveling thinning (default: 2.0)")
     parser.add_argument("--no_plot", action="store_true",
@@ -27,10 +29,11 @@ def main():
     args = parser.parse_args()
     opmd_path = Path(args.opmd_path)
     particle_species_name = args.species
+    particle_species_mass = args.mass
     reduction_factor = args.reduction_factor
 
     # Create the dataframe
-    df = ParticleDataReader.from_file(opmd_path, particle_species_name=particle_species_name)
+    df = ParticleDataReader.from_file(opmd_path, particle_species_name=particle_species_name, particle_species_mass=particle_species_mass)
 
     # Apply thinning algorithm to df, resulting in df_thin
     resampler = ParticleResampler(df)
@@ -44,7 +47,7 @@ def main():
 
     # Write the reduced dataframe to a file
     DataFrameToFile(df_thin).exclude_weights().exclude_energy().write_to_file(
-        opmd_path.with_suffix(".txt")
+        opmd_path.with_suffix(".dat")
     )
 
 

--- a/usage.py
+++ b/usage.py
@@ -18,7 +18,7 @@ def main():
     parser.add_argument("--species", "-s", type=str, default="e_all",
                         help="Particle species name (default: e_all)")
     parser.add_argument("--mass", "-m", type=float, default=1.0,
-                        help="Particle mass (default: 1.0)")
+                        help="Particle mass relative to the electron mass (default: 1.0)")
     parser.add_argument("--reduction_factor", "-k", type=float, default=2.0,
                         help="The 'k' level for global leveling thinning (default: 2.0)")
     parser.add_argument("--no_plot", action="store_true",


### PR DESCRIPTION
1. Add mass for ion particle species. The mass is a ratio to the electron mass. For example, the proton has a mass of 1836, and carbon has a mass of 1836*12. For electrons, it is 1.0; it is also the default value if the mass is not specified.
2. The energy spectrum has also been changed from total energy to kinetic energy, $E=\sqrt{p_x^2+p_y^2+p_z^2 + M^2c^2}$ to $E=\sqrt{p_x^2+p_y^2+p_z^2 + M^2c^2} - Mc^2$. This is equal to $E=(\gamma -1)Mc^2$. The energy in the spectrum is not divided by mass units. This has an impact on the Carbon energy spectrum which is usually in MeV/u.
3. The electrons[] array changed to particles[].
4. The output data extension changed to `.dat`.

The mass option only affects the energy spectrum plot.